### PR TITLE
Add heartbeat mechanism to Node

### DIFF
--- a/src/pqnstack/base/errors.py
+++ b/src/pqnstack/base/errors.py
@@ -50,3 +50,9 @@ class InvalidNetworkConfigurationError(Exception):
     def __init__(self, message: str = "Invalid network configuration") -> None:
         self.message = message
         super().__init__(self.message)
+
+
+class CouldNotConnectToNetworkElementError(Exception):
+    def __init__(self, message: str = "Could not connect to network element") -> None:
+        self.message = message
+        super().__init__(self.message)

--- a/src/pqnstack/cli.py
+++ b/src/pqnstack/cli.py
@@ -62,6 +62,8 @@ def _load_and_parse_node_config(
         kwargs["host"] = str(node["host"])
     if "port" in node:
         kwargs["port"] = int(node["port"])
+    if "beat_period" in node:
+        kwargs["beat_period"] = int(node["beat_period"])
 
     if "instruments" in node:
         instruments = _verify_instruments_config(node["instruments"])
@@ -84,13 +86,14 @@ def start_node(  # noqa: PLR0913
     port: Annotated[
         int | None, typer.Option(help="Port of the node (default: 5555). Has to be the same port as the Router.")
     ] = None,
+    beat_period: Annotated[int | None, typer.Option(help="Heartbeat period in milliseconds (default: 1000)")] = None,
     instruments: Annotated[
         str | None,
         typer.Option(
             help='JSON formatted string with necessary arguments to instantiate instruments. Example: \'{"dummy1": {"import": "pqnstack.pqn.drivers.dummies.DummyInstrument", "desc": "Dummy Instrument 1", "address": "123456"}}\''
         ),
     ] = None,
-    config_path: Annotated[
+    config: Annotated[
         str | None, typer.Option(help="Path to the config file, will get overridden by command line arguments.")
     ] = None,
 ) -> None:
@@ -102,8 +105,8 @@ def start_node(  # noqa: PLR0913
     kwargs: dict[str, str | int] = {}
     ins: dict[str, dict[str, str]] = {}
 
-    if config_path:
-        kwargs, ins = _load_and_parse_node_config(config_path, kwargs, ins)
+    if config:
+        kwargs, ins = _load_and_parse_node_config(config, kwargs, ins)
 
     if name:
         kwargs["name"] = name
@@ -113,6 +116,8 @@ def start_node(  # noqa: PLR0913
         kwargs["host"] = host
     if port:
         kwargs["port"] = port
+    if beat_period:
+        kwargs["beat_period"] = beat_period
     if instruments:
         # We don't want to override instruments, instead combining them with the ones from config file is cleaner behaviour.
         ins = {**ins, **json.loads(instruments)}

--- a/tests/messaging/config_example.toml
+++ b/tests/messaging/config_example.toml
@@ -8,6 +8,7 @@ name = "pqnstack-node"
 router_name = "pqnstack-router"
 host = "localhost"
 port = 5556
+beat_period = 2000
 
 [[node.instruments]]
 name = "dummy1"


### PR DESCRIPTION
Every specified x amount of milliseconds the Node sends a heartbeat (same message as packet registration) to the Router. This is done so the router can reconnect to the nodes automatically if the router ever goes down for some reason.

