### PR TITLE
Renaming node to provider & adding tests

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -29,13 +29,13 @@ All network elements implement a `dispatch` function that depends on the content
 ensures that routing information is adequately interpreted, and that the appropriate protocol is performed by the 
 desired node or group of nodes. The sequence of events in this case is as follows:
 
-1. **Node A** sends a packet to the router
+1. **InstrumentProvider A** sends a packet to the router
 2. The router determines the validity of the sender and the receiver
 3. The router extracts the signature of the packet, and separates the implementation into data, control and routing 
    backplane functions
-4. The router sends the packet to **Node B**
-5. **Node B** executes code implementing classical or quantum functions
-6. **Node B** prepares a response packet with `(source, destination)` being reversed from the original request
+4. The router sends the packet to **InstrumentProvider B**
+5. **InstrumentProvider B** executes code implementing classical or quantum functions
+6. **InstrumentProvider B** prepares a response packet with `(source, destination)` being reversed from the original request
 7. The router proceeds repeats steps 2-4
 8. If the packet `hops` value is zero, no further routing happens
 

--- a/src/pqnstack/cli.py
+++ b/src/pqnstack/cli.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from pqnstack.base.errors import InvalidNetworkConfigurationError
-from pqnstack.network.node import Node
+from pqnstack.network.instrument_provider import InstrumentProvider
 from pqnstack.network.router import Router
 
 # TODO: check if this way of handling logging from a command line script is ok.
@@ -40,51 +40,51 @@ def _verify_instruments_config(instruments: list[dict[str, str]]) -> dict[str, d
     return ins
 
 
-def _load_and_parse_node_config(
+def _load_and_parse_provider_config(
     config_path: Path | str, kwargs: dict[str, str | int], instruments: dict[str, dict[str, str]]
 ) -> tuple[dict[str, str | int], dict[str, dict[str, str]]]:
     path = Path(config_path)
     with path.open("rb") as f:
         config = tomllib.load(f)
 
-    if "node" not in config:
+    if "provider" not in config:
         msg = (
-            f"Config file {config_path} does not contain a node section. Add node configuration under '[node]' section."
+            f"Config file {config_path} does not contain a provider section. Add provider configuration under '[provider]' section."
         )
         raise InvalidNetworkConfigurationError(msg)
 
-    node = config["node"]
-    if "name" in node:
-        kwargs["name"] = str(node["name"])
-    if "router_name" in node:
-        kwargs["router_name"] = str(node["router_name"])
-    if "host" in node:
-        kwargs["host"] = str(node["host"])
-    if "port" in node:
-        kwargs["port"] = int(node["port"])
-    if "beat_period" in node:
-        kwargs["beat_period"] = int(node["beat_period"])
+    provider = config["provider"]
+    if "name" in provider:
+        kwargs["name"] = str(provider["name"])
+    if "router_name" in provider:
+        kwargs["router_name"] = str(provider["router_name"])
+    if "host" in provider:
+        kwargs["host"] = str(provider["host"])
+    if "port" in provider:
+        kwargs["port"] = int(provider["port"])
+    if "beat_period" in provider:
+        kwargs["beat_period"] = int(provider["beat_period"])
 
-    if "instruments" in node:
-        instruments = _verify_instruments_config(node["instruments"])
+    if "instruments" in provider:
+        instruments = _verify_instruments_config(provider["instruments"])
 
     return kwargs, instruments
 
 
 @app.command()
-def start_node(  # noqa: PLR0913
-    name: Annotated[str | None, typer.Option(help="Name of the Node.")] = None,
+def start_provider(  # noqa: PLR0913
+    name: Annotated[str | None, typer.Option(help="Name of the InstrumentProvider.")] = None,
     router_name: Annotated[
-        str | None, typer.Option(help="Name of the router this node will talk to (default: 'router1').")
+        str | None, typer.Option(help="Name of the router this provider will talk to (default: 'router1').")
     ] = None,
     host: Annotated[
         str | None,
         typer.Option(
-            help="Host address (IP) of the node (default: 'localhost'). Usually the IP address of the Router this node will talk to."
+            help="Host address (IP) of the provider (default: 'localhost'). Usually the IP address of the Router this provider will talk to."
         ),
     ] = None,
     port: Annotated[
-        int | None, typer.Option(help="Port of the node (default: 5555). Has to be the same port as the Router.")
+        int | None, typer.Option(help="Port of the provider (default: 5555). Has to be the same port as the Router.")
     ] = None,
     beat_period: Annotated[int | None, typer.Option(help="Heartbeat period in milliseconds (default: 1000)")] = None,
     instruments: Annotated[
@@ -98,7 +98,7 @@ def start_node(  # noqa: PLR0913
     ] = None,
 ) -> None:
     """
-    Start a PQN Node.
+    Start a PQN InstrumentProvider.
 
     Can be configured by passing arguments directly into the command line but it is recommended to use a config file if instruments will be added.
     """
@@ -106,7 +106,7 @@ def start_node(  # noqa: PLR0913
     ins: dict[str, dict[str, str]] = {}
 
     if config:
-        kwargs, ins = _load_and_parse_node_config(config, kwargs, ins)
+        kwargs, ins = _load_and_parse_provider_config(config, kwargs, ins)
 
     if name:
         kwargs["name"] = name
@@ -123,11 +123,11 @@ def start_node(  # noqa: PLR0913
         ins = {**ins, **json.loads(instruments)}
 
     if "name" not in kwargs:
-        msg = "Node name is required"
+        msg = "InstrumentProvider name is required"
         raise InvalidNetworkConfigurationError(msg)
 
-    node = Node(**kwargs, **ins)  # type: ignore[arg-type]
-    node.start()
+    provider = InstrumentProvider(**kwargs, **ins)  # type: ignore[arg-type]
+    provider.start()
 
 
 def _load_and_parse_router_config(config_path: Path | str, kwargs: dict[str, str | int]) -> dict[str, str | int]:

--- a/src/pqnstack/cli.py
+++ b/src/pqnstack/cli.py
@@ -48,9 +48,7 @@ def _load_and_parse_provider_config(
         config = tomllib.load(f)
 
     if "provider" not in config:
-        msg = (
-            f"Config file {config_path} does not contain a provider section. Add provider configuration under '[provider]' section."
-        )
+        msg = f"Config file {config_path} does not contain a provider section. Add provider configuration under '[provider]' section."
         raise InvalidNetworkConfigurationError(msg)
 
     provider = config["provider"]

--- a/src/pqnstack/network/packet.py
+++ b/src/pqnstack/network/packet.py
@@ -14,7 +14,7 @@ from pqnstack.base.errors import PacketError
 
 class NetworkElementClass(Enum):
     ROUTER = auto()
-    NODE = auto()
+    PROVIDER = auto()
     CLIENT = auto()
     TELEMETRY = auto()
 

--- a/tests/messaging/blocking_client.py
+++ b/tests/messaging/blocking_client.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     c = Client()
 
-    # ping node
-    ping_reply = c.ping("node1")
+    # ping provider
+    ping_reply = c.ping("provider1")
     logger.info(ping_reply)
 
-    instrument = c.get_device("node1", "dummy1")
+    instrument = c.get_device("provider1", "dummy1")
     logger.info(instrument)
 
     # blocking operation

--- a/tests/messaging/client.py
+++ b/tests/messaging/client.py
@@ -9,15 +9,15 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     c = Client()
 
-    # ping node
-    ping_reply = c.ping("node1")
+    # ping provider
+    ping_reply = c.ping("provider1")
     logger.info(ping_reply)
 
-    devices = c.get_available_devices("node1")
+    devices = c.get_available_devices("provider1")
     logger.info(devices)
 
     # Create instrument proxy
-    instrument = c.get_device("node1", "dummy1")
+    instrument = c.get_device("provider1", "dummy1")
     logger.info(instrument)
     logger.info("I should have the proxy object here: %s", type(instrument))
 

--- a/tests/messaging/config_example.toml
+++ b/tests/messaging/config_example.toml
@@ -3,20 +3,20 @@ name = "pqnstack-router"
 host = "localhost"
 port = 5556
 
-[node]
-name = "pqnstack-node"
+[provider]
+name = "pqnstack-provider"
 router_name = "pqnstack-router"
 host = "localhost"
 port = 5556
 beat_period = 2000
 
-[[node.instruments]]
+[[provider.instruments]]
 name = "dummy1"
 import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
 desc = "Dummy instrument1 for testing purposes"
 address = "1234"
 
-[[node.instruments]]
+[[provider.instruments]]
 name = "dummy2"
 import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
 desc = "Dummy instrument2 for testing purposes"

--- a/tests/messaging/provider.py
+++ b/tests/messaging/provider.py
@@ -1,6 +1,6 @@
 import logging
 
-from pqnstack.network.node import Node
+from pqnstack.network.instrument_provider import InstrumentProvider
 
 logging.basicConfig(level=logging.INFO)
 
@@ -12,5 +12,5 @@ if __name__ == "__main__":
             "address": "123456",
         }
     }
-    node = Node("node1", "127.0.0.1", 5555, **instruments)
-    node.start()
+    provider = InstrumentProvider("provider1", "127.0.0.1", 5555, **instruments)
+    provider.start()

--- a/tests/pytest/test_internal_network.py
+++ b/tests/pytest/test_internal_network.py
@@ -13,7 +13,7 @@ from pqnstack.pqn.drivers.dummies import DummyInstrument
 
 @pytest.fixture
 def messaging_services():
-    config_path = Path("./test_network_config.toml").resolve()
+    config_path = Path("./tests/pytest/test_network_config.toml").resolve()
     uv_path = shutil.which("uv")
     if not uv_path:
         msg = "Could not find 'uv' executable in PATH"
@@ -42,7 +42,7 @@ def messaging_services():
     provider_process.wait()
 
 
-def test_client_ping(messaging_services): # noqa: ARG001
+def test_client_ping(messaging_services):  # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
     response = client.ping("pqnstack-provider")
 
@@ -53,7 +53,7 @@ def test_client_ping(messaging_services): # noqa: ARG001
     assert response.request == "PONG"
 
 
-def test_getting_all_instruments(messaging_services): # noqa: ARG001
+def test_getting_all_instruments(messaging_services):  # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
 
     response = client.get_available_devices("pqnstack-provider")
@@ -66,7 +66,7 @@ def test_getting_all_instruments(messaging_services): # noqa: ARG001
     assert isinstance(response["dummy2"], DummyInstrument.__class__)
 
 
-def test_proxy_instrument(messaging_services): # noqa: ARG001
+def test_proxy_instrument(messaging_services):  # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
 
     proxy_instrument = client.get_device("pqnstack-provider", "dummy1")

--- a/tests/pytest/test_internal_network.py
+++ b/tests/pytest/test_internal_network.py
@@ -13,7 +13,7 @@ from pqnstack.pqn.drivers.dummies import DummyInstrument
 
 @pytest.fixture
 def messaging_services():
-    config_path = Path("./tests/pytest/test_network_config.toml").resolve()
+    config_path = Path("./test_network_config.toml").resolve()
     uv_path = shutil.which("uv")
     if not uv_path:
         msg = "Could not find 'uv' executable in PATH"
@@ -26,8 +26,8 @@ def messaging_services():
         shell=False,
     )
 
-    node_process = subprocess.Popen(  # noqa: S603
-        [uv_path, "run", "pqn", "start-node", "--config", str(config_path)],
+    provider_process = subprocess.Popen(  # noqa: S603
+        [uv_path, "run", "pqn", "start-provider", "--config", str(config_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         shell=False,
@@ -38,17 +38,17 @@ def messaging_services():
     router_process.terminate()
     router_process.wait()
 
-    node_process.terminate()
-    node_process.wait()
+    provider_process.terminate()
+    provider_process.wait()
 
 
 def test_client_ping(messaging_services): # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
-    response = client.ping("pqnstack-node")
+    response = client.ping("pqnstack-provider")
 
     assert isinstance(response, Packet)
     assert response.intent == PacketIntent.PING
-    assert response.source == "pqnstack-node"
+    assert response.source == "pqnstack-provider"
     assert response.destination == client.name
     assert response.request == "PONG"
 
@@ -56,7 +56,7 @@ def test_client_ping(messaging_services): # noqa: ARG001
 def test_getting_all_instruments(messaging_services): # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
 
-    response = client.get_available_devices("pqnstack-node")
+    response = client.get_available_devices("pqnstack-provider")
 
     instruments_names = ["dummy1", "dummy2"]
 
@@ -69,7 +69,7 @@ def test_getting_all_instruments(messaging_services): # noqa: ARG001
 def test_proxy_instrument(messaging_services): # noqa: ARG001
     client = Client(host="localhost", port=5556, router_name="pqnstack-router")
 
-    proxy_instrument = client.get_device("pqnstack-node", "dummy1")
+    proxy_instrument = client.get_device("pqnstack-provider", "dummy1")
     assert isinstance(proxy_instrument, ProxyInstrument)
 
     base_int = 2

--- a/tests/pytest/test_internal_network.py
+++ b/tests/pytest/test_internal_network.py
@@ -1,0 +1,99 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pqnstack.network.client import Client
+from pqnstack.network.client import ProxyInstrument
+from pqnstack.network.packet import Packet
+from pqnstack.network.packet import PacketIntent
+from pqnstack.pqn.drivers.dummies import DummyInstrument
+
+
+@pytest.fixture
+def messaging_services():
+    config_path = Path("./tests/pytest/test_network_config.toml").resolve()
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        msg = "Could not find 'uv' executable in PATH"
+        raise RuntimeError(msg)
+
+    router_process = subprocess.Popen(  # noqa: S603
+        [uv_path, "run", "pqn", "start-router", "--config", str(config_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+
+    node_process = subprocess.Popen(  # noqa: S603
+        [uv_path, "run", "pqn", "start-node", "--config", str(config_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+
+    yield
+
+    router_process.terminate()
+    router_process.wait()
+
+    node_process.terminate()
+    node_process.wait()
+
+
+def test_client_ping(messaging_services): # noqa: ARG001
+    client = Client(host="localhost", port=5556, router_name="pqnstack-router")
+    response = client.ping("pqnstack-node")
+
+    assert isinstance(response, Packet)
+    assert response.intent == PacketIntent.PING
+    assert response.source == "pqnstack-node"
+    assert response.destination == client.name
+    assert response.request == "PONG"
+
+
+def test_getting_all_instruments(messaging_services): # noqa: ARG001
+    client = Client(host="localhost", port=5556, router_name="pqnstack-router")
+
+    response = client.get_available_devices("pqnstack-node")
+
+    instruments_names = ["dummy1", "dummy2"]
+
+    assert instruments_names == list(response.keys())
+    # Get available devices returns the __class__ of the instrument as the value.
+    assert isinstance(response["dummy1"], DummyInstrument.__class__)
+    assert isinstance(response["dummy2"], DummyInstrument.__class__)
+
+
+def test_proxy_instrument(messaging_services): # noqa: ARG001
+    client = Client(host="localhost", port=5556, router_name="pqnstack-router")
+
+    proxy_instrument = client.get_device("pqnstack-node", "dummy1")
+    assert isinstance(proxy_instrument, ProxyInstrument)
+
+    base_int = 2
+    double_int = base_int * 2
+    arbitrary_int = 12
+
+    assert proxy_instrument.name == "dummy1"
+    assert proxy_instrument.param_int == base_int
+    assert proxy_instrument.param_str == "hello"
+
+    assert proxy_instrument.double_int() == double_int
+    assert proxy_instrument.param_int == double_int
+
+    proxy_instrument.param_int = arbitrary_int
+    assert proxy_instrument.param_int == arbitrary_int
+
+    assert proxy_instrument.uppercase_str() == "HELLO"
+    assert proxy_instrument.param_str == "HELLO"
+
+    # Make sure you cannot add attributes to the proxy instrument
+    fail_flag = False
+    try:
+        proxy_instrument.new_attr = 42
+    except AttributeError:
+        fail_flag = True
+
+    assert fail_flag, "Should not be able to set new attributes on the ProxyInstrument"

--- a/tests/pytest/test_network_config.toml
+++ b/tests/pytest/test_network_config.toml
@@ -3,20 +3,20 @@ name = "pqnstack-router"
 host = "localhost"
 port = 5556
 
-[node]
-name = "pqnstack-node"
+[provider]
+name = "pqnstack-provider"
 router_name = "pqnstack-router"
 host = "localhost"
 port = 5556
 beat_period = 2000
 
-[[node.instruments]]
+[[provider.instruments]]
 name = "dummy1"
 import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
 desc = "Dummy instrument1 for testing purposes"
 address = "1234"
 
-[[node.instruments]]
+[[provider.instruments]]
 name = "dummy2"
 import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
 desc = "Dummy instrument2 for testing purposes"

--- a/tests/pytest/test_network_config.toml
+++ b/tests/pytest/test_network_config.toml
@@ -1,0 +1,23 @@
+[router]
+name = "pqnstack-router"
+host = "localhost"
+port = 5556
+
+[node]
+name = "pqnstack-node"
+router_name = "pqnstack-router"
+host = "localhost"
+port = 5556
+beat_period = 2000
+
+[[node.instruments]]
+name = "dummy1"
+import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
+desc = "Dummy instrument1 for testing purposes"
+address = "1234"
+
+[[node.instruments]]
+name = "dummy2"
+import = "pqnstack.pqn.drivers.dummies.DummyInstrument"
+desc = "Dummy instrument2 for testing purposes"
+address = "1234"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
 wheels = [
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "pqnstack"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
I have renamed every mention of the old `Node` into `InstrumentProvider` or `provider` when appropriate.

New pytests have been added to test the basic behavior of them as well. To test them simply run pytest in the root of the project: `uv run pytest`

