### PR TITLE
Adds config files for the API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pqn = "pqnstack.cli:app"
 
 [project.optional-dependencies]
 webapp = [
+    "dotenv>=0.9.9",
     "fastapi[standard]>=0.115.14",
     "httpx>=0.28.1",
     "pydantic>=2.11.7",

--- a/src/pqnstack/app/core/config.py
+++ b/src/pqnstack/app/core/config.py
@@ -20,7 +20,7 @@ class CHSHSettings(BaseModel):
     # Specifies which half waveplate to use for the CHSH experiment. First value is the provider's name, second is the motor name.
     hwp: tuple[str, str] = ("", "")
     request_hwp: tuple[str, str] = ("", "")
-    measurement_config: MeasurementConfig = Field(default_factory=lambda: MeasurementConfig(duration=5))
+    measurement_config: MeasurementConfig = Field(default_factory=lambda: MeasurementConfig(integration_time_s=5))
 
 
 class QKDSettings(BaseModel):
@@ -28,7 +28,7 @@ class QKDSettings(BaseModel):
     request_hwp: tuple[str, str] = ("", "")
     bitstring_length: int = 4
     discriminating_threshold: int = 10
-    measurement_config: MeasurementConfig = Field(default_factory=lambda: MeasurementConfig(duration=5))
+    measurement_config: MeasurementConfig = Field(default_factory=lambda: MeasurementConfig(integration_time_s=5))
 
 
 class Settings(BaseModel):

--- a/src/pqnstack/pqn/protocols/measurement.py
+++ b/src/pqnstack/pqn/protocols/measurement.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from pydantic import BaseModel
 
 
 @dataclass
-class MeasurementConfig:
+class MeasurementConfig(BaseModel):
     integration_time_s: float
     binwidth_ps: int = 500
     channel1: int = 1

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,17 @@ wheels = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.9.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dotenv" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892 },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +446,7 @@ dependencies = [
 
 [package.optional-dependencies]
 webapp = [
+    { name = "dotenv" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "pydantic" },
@@ -449,6 +461,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dotenv", marker = "extra == 'webapp'", specifier = ">=0.9.9" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'webapp'", specifier = ">=0.115.14" },
     { name = "httpx", marker = "extra == 'webapp'", specifier = ">=0.28.1" },
     { name = "numpy", specifier = "<2.0" },


### PR DESCRIPTION
The server looks for a file called `config.toml` wherever is running, and if it cannot find it there it looks for a file specified in the environment variable `API_CONFIG_PATH`

Config files should look something like this:


```TOML
# Router configuration
router_name = "router1"
router_address = "xx.xx.xx.xx"
router_port = 5555

# Timetagger configuration (provider_name, instrument_name)
timetagger = ["provider", "ins"]

# Bell state configuration (default: Phi_plus)
bell_state = 0

# CHSH experiment settings
[chsh_settings]
hwp = ["provider", "ins"]
request_hwp = ["provider", "ins"]

# CHSH measurement configuration
[chsh_settings.measurement_config]
integration_time_s= 5
binwidth = 500
channel1 = 1
channel2 = 2
dark_count = 0

# QKD experiment settings
[qkd_settings]
hwp = ["provider", "ins"]
request_hwp = ["provider", "ins"]
bitstring_length = 4
discriminating_threshold = 10

# QKD measurement configuration
[qkd_settings.measurement_config]
integration_time_s = 5
binwidth = 500
channel1 = 1
channel2 = 2
dark_count = 0
```