### PR TITLE
Add game available to configs and endpoint for frontend to check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyfirmata2>=2.5.0",
     "pyzmq>=26.2.0",
     "thorlabs-apt-device>=0.3.8",
+    "tomli-w>=1.0.0",
     "typer>=0.15.1",
 ]
 
@@ -31,7 +32,6 @@ webapp = [
     "fastapi[standard]>=0.115.14",
     "httpx>=0.28.1",
     "pydantic-settings>=2.10.1",
-    "tomli-w>=1.0.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ webapp = [
     "fastapi[standard]>=0.115.14",
     "httpx>=0.28.1",
     "pydantic-settings>=2.10.1",
+    "tomli-w>=1.0.0",
 ]
 
 [dependency-groups]

--- a/src/pqnstack/app/api/main.py
+++ b/src/pqnstack/app/api/main.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from pqnstack.app.api.routes import chsh
 from pqnstack.app.api.routes import coordination
 from pqnstack.app.api.routes import debug
+from pqnstack.app.api.routes import games
 from pqnstack.app.api.routes import qkd
 from pqnstack.app.api.routes import rng
 from pqnstack.app.api.routes import serial
@@ -16,3 +17,4 @@ api_router.include_router(rng.router)
 api_router.include_router(serial.router)
 api_router.include_router(coordination.router)
 api_router.include_router(debug.router)
+api_router.include_router(games.router)

--- a/src/pqnstack/app/api/routes/games.py
+++ b/src/pqnstack/app/api/routes/games.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from pqnstack.app.core.config import GamesAvailability, get_settings
+from pqnstack.app.core.config import GamesAvailability
+from pqnstack.app.core.config import get_settings
 
 router = APIRouter(prefix="/games", tags=["games"])
 

--- a/src/pqnstack/app/api/routes/games.py
+++ b/src/pqnstack/app/api/routes/games.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from pqnstack.app.core.config import GamesAvailability, get_settings
+
+router = APIRouter(prefix="/games", tags=["games"])
+
+
+@router.get("/availability")
+def get_availability() -> GamesAvailability:
+    return get_settings().games_availability

--- a/src/pqnstack/app/core/config.py
+++ b/src/pqnstack/app/core/config.py
@@ -43,6 +43,12 @@ class QKDSettings(BaseModel):
     measurement_config: MeasurementConfig = Field(default_factory=lambda: MeasurementConfig(integration_time_s=5))
 
 
+class GamesAvailability(BaseModel):
+    chsh: bool = True  # "Verify Quantum Link"
+    qf: bool = True  # "Quantum Fortune"
+    ssm: bool = True  # "Share a Secret Message"
+
+
 class Settings(BaseSettings):
     node_name: str = "node1"
     router_name: str = "router1"
@@ -54,6 +60,7 @@ class Settings(BaseSettings):
     timetagger: tuple[str, str] | None = None  # Name of the timetagger to use for the CHSH experiment.
     rotary_encoder_address: str = "/dev/ttyACM0"
     virtual_rotator: bool = False  # If True, use terminal input instead of hardware rotary encoder
+    games_availability: GamesAvailability = Field(default_factory=GamesAvailability)
 
     model_config = SettingsConfigDict(
         toml_file="./config.toml",

--- a/src/pqnstack/cli.py
+++ b/src/pqnstack/cli.py
@@ -4,6 +4,7 @@ import tomllib
 from pathlib import Path
 from typing import Annotated
 
+import tomli_w
 import typer
 
 from pqnstack.base.errors import InvalidNetworkConfigurationError
@@ -187,7 +188,7 @@ def start_router(
 @app.command()
 def toggle_game(
     games: Annotated[list[str], typer.Argument(help="Games to toggle: chsh, qf, ssm")],
-    enable: Annotated[bool, typer.Option("--enable/--disable", help="Enable or disable the games")] = True,
+    enable: Annotated[bool, typer.Option("--enable/--disable", help="Enable or disable the games")] = True,  # noqa: FBT002
     config: Annotated[str, typer.Option(help="Path to config.toml")] = "./config.toml",
 ) -> None:
     """
@@ -195,10 +196,6 @@ def toggle_game(
 
     Changes take effect on the next server restart. Games: chsh (Verify Quantum Link), qf (Quantum Fortune), ssm (Share a Secret Message).
     """
-    import tomllib
-
-    import tomli_w
-
     valid_games = {"chsh", "qf", "ssm"}
     invalid = [g for g in games if g not in valid_games]
     if invalid:

--- a/src/pqnstack/cli.py
+++ b/src/pqnstack/cli.py
@@ -184,5 +184,41 @@ def start_router(
     router.start()
 
 
+@app.command()
+def toggle_game(
+    games: Annotated[list[str], typer.Argument(help="Games to toggle: chsh, qf, ssm")],
+    enable: Annotated[bool, typer.Option("--enable/--disable", help="Enable or disable the games")] = True,
+    config: Annotated[str, typer.Option(help="Path to config.toml")] = "./config.toml",
+) -> None:
+    """
+    Enable or disable one or more games in config.toml.
+
+    Changes take effect on the next server restart. Games: chsh (Verify Quantum Link), qf (Quantum Fortune), ssm (Share a Secret Message).
+    """
+    import tomllib
+
+    import tomli_w
+
+    valid_games = {"chsh", "qf", "ssm"}
+    invalid = [g for g in games if g not in valid_games]
+    if invalid:
+        msg = f"Game(s) must be one of: chsh, qf, ssm. Invalid: {invalid}"
+        raise InvalidNetworkConfigurationError(msg)
+
+    path = Path(config)
+    with path.open("rb") as f:
+        cfg = tomllib.load(f)
+
+    cfg.setdefault("games_availability", {})
+    for game in games:
+        cfg["games_availability"][game] = enable
+
+    with path.open("wb") as f:
+        tomli_w.dump(cfg, f)
+
+    status = "enabled" if enable else "disabled"
+    logger.info("Games %s %s in %s. Restart the server for changes to take effect.", games, status, path)
+
+
 if __name__ == "__main__":
     app()

--- a/uv.lock
+++ b/uv.lock
@@ -733,6 +733,7 @@ dependencies = [
     { name = "pyfirmata2" },
     { name = "pyzmq" },
     { name = "thorlabs-apt-device" },
+    { name = "tomli-w" },
     { name = "typer" },
 ]
 
@@ -741,7 +742,6 @@ webapp = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "pydantic-settings" },
-    { name = "tomli-w" },
 ]
 
 [package.dev-dependencies]
@@ -762,7 +762,7 @@ requires-dist = [
     { name = "pyfirmata2", specifier = ">=2.5.0" },
     { name = "pyzmq", specifier = ">=26.2.0" },
     { name = "thorlabs-apt-device", specifier = ">=0.3.8" },
-    { name = "tomli-w", marker = "extra == 'webapp'", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 provides-extras = ["webapp"]

--- a/uv.lock
+++ b/uv.lock
@@ -741,6 +741,7 @@ webapp = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "pydantic-settings" },
+    { name = "tomli-w" },
 ]
 
 [package.dev-dependencies]
@@ -761,6 +762,7 @@ requires-dist = [
     { name = "pyfirmata2", specifier = ">=2.5.0" },
     { name = "pyzmq", specifier = ">=26.2.0" },
     { name = "thorlabs-apt-device", specifier = ">=0.3.8" },
+    { name = "tomli-w", marker = "extra == 'webapp'", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 provides-extras = ["webapp"]
@@ -1228,6 +1230,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/72/e046337437e882d232d77fd6d4b09bccf3c0f3a8689faa122f714f09d508/thorlabs_apt_device-0.3.8.tar.gz", hash = "sha256:1f51cc7b80ca63cf841d96f2172f420d53890cf049b33458e283dbe248eb22f9", size = 55078, upload-time = "2024-03-09T09:39:19.579Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/38/60afff0deb2379c5feae251a5da9e9773c6ac8e2f09fbdac8d2980e28aa2/thorlabs_apt_device-0.3.8-py3-none-any.whl", hash = "sha256:84897581dc99e6f1ab774f07f9466d9137c94ac3dfa0fa59cdd305a4c9682872", size = 64631, upload-time = "2024-03-09T09:39:16.829Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds a `GamesAvailability` configuration model and a `/games/availability` API endpoint so the frontend can check which games are enabled on a given node. Also adds a `toggle_game` CLI command to enable/disable games in `config.toml` without manually editing the file.

Changes:
- **config.py**: New `GamesAvailability` pydantic model (fields: `chsh`, `qf`, `ssm`, all defaulting to `True`) added as a field on `Settings`
- **routes/games.py**: New `/games/availability` GET endpoint returning the current `GamesAvailability`
- **cli.py**: New `toggle_game` CLI command — accepts one or more game names and `--enable`/`--disable`, writes the updated value back to `config.toml` using `tomli-w`
- **pyproject.toml / uv.lock**: Added `tomli-w` dependency (webapp extra)

## Motivation and Context
The frontend needs to know which games are available on each node so it can show or hide game options accordingly. This allows node operators to configure game availability via `config.toml` rather than requiring code changes or frontend-specific config.

## How have these changes been tested?
- Verified the `/games/availability` endpoint returns the correct defaults and respects values set in `config.toml`
- Tested `toggle_game` CLI command with `--enable` and `--disable` for each game (`chsh`, `qf`, `ssm`) and confirmed the `config.toml` is updated correctly
- Confirmed the server must be restarted for config changes to take effect

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My changes require changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.