### PR TITLE
Add regression tests for games-availability and fix sticky availabili…

### DIFF
--- a/src/pqn_node/api/main.py
+++ b/src/pqn_node/api/main.py
@@ -9,8 +9,8 @@ from pqn_node.api.routes import qkd
 from pqn_node.api.routes import rng
 from pqn_node.api.routes import serial
 from pqn_node.api.routes import timetagger
+from pqn_node.api.routes.health import get_effective_availability
 from pqn_node.core.config import GamesAvailability
-from pqn_node.core.config import get_settings
 from pqn_node.core.config import settings
 
 
@@ -31,7 +31,7 @@ api_router.include_router(health.router)
 
 @api_router.get("/games/availability", tags=["games"])
 def get_availability() -> GamesAvailability:
-    return get_settings().games_availability
+    return get_effective_availability()
 
 
 @api_router.get("/node/config", tags=["node"])

--- a/src/pqn_node/api/routes/health.py
+++ b/src/pqn_node/api/routes/health.py
@@ -10,6 +10,7 @@ from pqn_hardware.network.client import Client
 from pydantic import BaseModel
 from pydantic import Field
 
+from pqn_node.core.config import GamesAvailability
 from pqn_node.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,31 @@ _FOLLOWER_TIMEOUT_S = 5.0
 _FOLLOWER_WALL_TIMEOUT_S = 6.0
 
 _probe_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="health-probe")
+
+
+class _AvailabilityCache:
+    """Holds what `/games/availability` reports: the last probe's gated result.
+
+    The invariant, which the sticky-availability bug came from violating:
+
+        value == effective_availability(config.toml, most recent probe)
+
+    `value` is a pure function of those two inputs and carries no history. Every
+    probe *overwrites* it with a freshly computed result — the previous value is
+    never read back as an input, so a stale False cannot influence, and cannot
+    survive, the next probe. This is deliberately a cache beside the settings
+    singleton rather than a mutation of it: `settings.games_availability` stays
+    pristine as the configured baseline, because that baseline is what each
+    recomputation starts from. Mutating it in place (as this code once did) makes
+    the output its own next input, which latches the flags off permanently.
+
+    `value` is None until the first probe runs; see `get_effective_availability`.
+    """
+
+    value: GamesAvailability | None = None
+
+
+_availability_cache = _AvailabilityCache()
 
 
 def _run_with_timeout[T](fn: Callable[[], T], timeout_s: float) -> T:
@@ -212,7 +238,9 @@ def health() -> HealthStatus:
     else:
         follower_node = None
 
-    _apply_games_override(router_status, follower_node)
+    # Refresh what /games/availability reports. Recomputed from the pristine config
+    # (never from the cached value) so games recover once hardware comes back.
+    _availability_cache.value = effective_availability(settings.games_availability, router_status, follower_node)
 
     return HealthStatus(
         router=router_status,
@@ -222,8 +250,32 @@ def health() -> HealthStatus:
     )
 
 
-def _apply_games_override(router_status: ComponentStatus, follower_node: ComponentStatus | None) -> None:
-    ga = settings.games_availability
+def effective_availability(
+    configured: GamesAvailability,
+    router_status: ComponentStatus,
+    follower_node: ComponentStatus | None,
+) -> GamesAvailability:
+    """Gate the configured game availability on live hardware reachability.
+
+    Pure: same inputs always give the same answer, and neither `configured` nor
+    any shared state is mutated. Callers own the returned copy.
+
+    Two properties follow from starting at `configured` and only ever clearing
+    flags, and both are load-bearing:
+
+    - **Games recover on their own.** The result is re-derived from config each
+      call rather than revised from the previous result, so once the hardware is
+      reachable again the next probe returns True with no explicit re-enable
+      step. There is nothing to reset by hand and no restart needed.
+    - **config.toml is an absolute veto.** No branch here assigns True, so a game
+      disabled in config can never be switched on by a healthy probe.
+
+    `configured` must therefore be the pristine values parsed from config.toml —
+    pass `settings.games_availability`, never a previously gated result. Passing
+    a gated result back in reintroduces the latching bug this function replaced:
+    the flags would ratchet toward all-off and stay there.
+    """
+    ga = configured.model_copy()
     if not router_status.reachable:
         ga.chsh = False
         ga.qf = False
@@ -231,3 +283,20 @@ def _apply_games_override(router_status: ComponentStatus, follower_node: Compone
     elif follower_node is not None and not follower_node.reachable:
         ga.chsh = False
         ga.ssm = False
+    return ga
+
+
+def get_effective_availability() -> GamesAvailability:
+    """Return the availability computed by the most recent health probe.
+
+    Backs `GET /games/availability`. Read-only: this does not probe hardware, so
+    the answer is only as fresh as the last `health()` call. Today that means app
+    startup, the daily report, and any manual hit on `/health/` — so hitting
+    `/health/` is what re-enables games on a node whose hardware has recovered.
+
+    Falls back to the configured values when no probe has run yet, so the
+    endpoint reports config rather than claiming everything is disabled.
+    """
+    if _availability_cache.value is None:
+        return settings.games_availability.model_copy()
+    return _availability_cache.value

--- a/tests/pytest/test_games_availability.py
+++ b/tests/pytest/test_games_availability.py
@@ -1,0 +1,69 @@
+"""Regression tests for the games-availability gate.
+
+The bug these cover: the health probe used to mutate the process-wide settings
+singleton and could only ever assign False, so one unreachable-router probe
+disabled every game until the process restarted.
+"""
+
+from pqn_node.api.routes.health import ComponentStatus
+from pqn_node.api.routes.health import effective_availability
+from pqn_node.core.config import GamesAvailability
+from pqn_node.core.config import get_settings
+
+UP = ComponentStatus(reachable=True)
+DOWN = ComponentStatus(reachable=False, error="unreachable")
+
+
+def test_all_games_gated_off_when_router_unreachable() -> None:
+    result = effective_availability(GamesAvailability(chsh=True, qf=True, ssm=True), DOWN, UP)
+    assert (result.chsh, result.qf, result.ssm) == (False, False, False)
+
+
+def test_follower_unreachable_leaves_qf_enabled() -> None:
+    result = effective_availability(GamesAvailability(chsh=True, qf=True, ssm=True), UP, DOWN)
+    assert (result.chsh, result.qf, result.ssm) == (False, True, False)
+
+
+def test_no_follower_configured_does_not_gate() -> None:
+    result = effective_availability(GamesAvailability(chsh=True, qf=True, ssm=True), UP, None)
+    assert (result.chsh, result.qf, result.ssm) == (True, True, True)
+
+
+def test_games_re_enable_once_hardware_recovers() -> None:
+    """The whole point: the gate is re-derived from config, not latched."""
+    configured = GamesAvailability(chsh=True, qf=True, ssm=True)
+
+    while_down = effective_availability(configured, DOWN, UP)
+    assert not while_down.qf
+
+    after_recovery = effective_availability(configured, UP, UP)
+    assert (after_recovery.chsh, after_recovery.qf, after_recovery.ssm) == (True, True, True)
+
+
+def test_config_disabled_game_is_never_enabled_by_a_healthy_probe() -> None:
+    configured = GamesAvailability(chsh=False, qf=True, ssm=False)
+
+    result = effective_availability(configured, UP, UP)
+
+    assert result.chsh is False
+    assert result.ssm is False
+    assert result.qf is True
+
+
+def test_gating_does_not_mutate_the_configured_object() -> None:
+    configured = GamesAvailability(chsh=True, qf=True, ssm=True)
+
+    effective_availability(configured, DOWN, DOWN)
+
+    assert (configured.chsh, configured.qf, configured.ssm) == (True, True, True)
+
+
+def test_gating_does_not_mutate_the_settings_singleton() -> None:
+    """A failed probe must not poison process-wide state."""
+    configured = get_settings().games_availability
+    before = (configured.chsh, configured.qf, configured.ssm)
+
+    effective_availability(configured, DOWN, DOWN)
+
+    after = get_settings().games_availability
+    assert (after.chsh, after.qf, after.ssm) == before


### PR DESCRIPTION
## Description

`GET /health/` mutated the process-wide settings singleton and could only ever assign `False`, never `True`. One probe that saw the router unreachable disabled every game in memory, permanently — `GET /games/availability` then returned `{"chsh": false, "qf": false, "ssm": false}` for the rest of the process lifetime, even after the hardware fully recovered.

This replaces the mutation with a pure function plus a small cache.

- `_apply_games_override` → `effective_availability(configured, router_status, follower_node)`. The gating logic itself is unchanged; the substantive difference is `ga = configured.model_copy()` instead of `ga = settings.games_availability`, plus a `return`.
- `health()` stores the result in a module-level `_AvailabilityCache` instead of writing into `settings`.
- `/games/availability` reads that cache via `get_effective_availability()`, falling back to config if no probe has run yet.

`settings.games_availability` is now written exactly once, when `Settings()` is constructed, and is never touched again at runtime.

## Motivation and Context

Two facts combined into the bug.

**1. `settings` and `get_settings()` are the same object.** `get_settings()` is `@lru_cache`'d and `settings = get_settings()` binds the module-level name to that one instance (`core/config.py:100-105`). Mutating either mutates the single process-wide `Settings`.

**2. The gate was a read-modify-write on that object.** `settings.games_availability` was both the configured baseline *and* the destination for the gated result. Once `False` was written, the next probe read `False` as its starting point and had nowhere to go — the output was its own next input. The values from `config.toml` were destroyed in memory and not re-read until restart.

The fix breaks that cycle. Every probe recomputes from the pristine config and overwrites the cache; the previous cached value is never read back:

```
config (pristine)  ─┐
                    ├──> effective_availability() ──> overwrite cache
probe result       ─┘
```

Two properties follow from starting at `configured` and only ever clearing flags:

- **Games recover on their own.** No explicit re-enable branch exists or is needed — a healthy probe naturally yields `True` again, because it starts from config rather than from the last result. Hitting `/health/` now un-sticks a node whose hardware has come back; previously only a restart could, and not reliably.
- **`config.toml` is an absolute veto.** No branch assigns `True`, so a game disabled in config can never be switched on by a healthy probe. This is structural rather than conditional — there is no code path that could get it wrong.

The invariant, documented on `_AvailabilityCache`:

```
value == effective_availability(config.toml, most recent probe)
```

A pure function of two inputs, carrying no history. Knowing those two things tells you what the endpoint returns, without knowing how many probes ran or in what order they failed.

### Scope

Deliberately narrow: this fixes the latch, not the trigger. `health()` is still only invoked at app startup (`main.py:18`) and by the daily report, so recovery is currently driven by anything that hits `/health/` — startup, the daily report, or a manual request. Periodic re-probing is intentionally left for the follow-on work that will own it.

Also unchanged on purpose: device reachability still does not gate anything (an unreachable CHSH waveplate does not disable `chsh`). That's arguably wrong, but it is pre-existing behavior and out of scope here.

## How have these changes been tested?

New `tests/pytest/test_games_availability.py` — 7 tests, all passing:

- the three gating cases (router down → all off; follower down → `qf` survives; no follower configured → no gating)
- **recovery**: a gated-off result followed by a healthy probe returns all `True` — the regression that would have caught this bug
- **config veto**: a healthy probe does not enable games disabled in config
- **no mutation** of the passed-in object, and of `get_settings().games_availability`, after an unreachable-router probe

Full suite: `8 passed`. Also clean under `ruff check` (`select = ["ALL"]`), `ruff format --check`, and `mypy --strict`.

Not yet verified on hardware. The original report is from `ufl-public-left` (2026-07-16); worth confirming there that a node with a downed router re-enables its games after the router returns and `/health/` is hit, with no restart.

### Note on the original diagnosis

The write-up this came from stated that the GUI polls `/health/` continuously, and concluded restarts were therefore unreliable. That is not the case — `grep -i health` across `pqn-gui/src` returns nothing, and the GUI fetches `/games/availability` exactly once on mount (`app/page.tsx:29-37`). `/health/` callers are `main.py:18` (startup), `daily_report.py:126`, and manual requests.

So the likeliest reason the clean restart didn't help is a **startup race**: the `lifespan` probe fires before the ZMQ router registration is usable, so it records the router as unreachable a moment before `/health/` would report green. The latch then made that verdict permanent. The fix addresses the latch regardless of which trigger fired; the race is worth confirming separately.

`games_availability_sticky_bug.md` and `WHOBOT.md` (lines 23 and 381) still carry the continuous-polling claim, and `WHOBOT.md:381` prescribes a test strategy built on it. Those need a follow-up correction; not touched in this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

`/games/availability` keeps its response schema. Its *semantics* are now "config gated by the most recent probe" rather than "config gated by the first probe, permanently" — which is the intended behavior, and what the daily report already assumed by probing `/health/` immediately before reading availability (`daily_report.py:457-462`).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My changes require changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.

Docs are deliberately not updated here — the two stale files are unrelated to this diff and are better corrected on their own. Behavior is documented in-code: the invariant and the failure mode it prevents on `_AvailabilityCache`, and the caller contract on `effective_availability` (pass the pristine config, never a previously gated result — feeding its own output back in would reintroduce the ratchet).

### Reviewer notes

- `get_effective_availability()` returns the cached object by reference, not a copy. Nothing mutates it today, but a future caller that did would write into the cache. Happy to add a `.model_copy()` if you'd prefer that closed off now.
- `_AvailabilityCache` is a holder class rather than a module-level `global`, because ruff's `PLW0603` rejects the latter under `select = ["ALL"]`.
- The `_AvailabilityCache` docstring references the historical bug on purpose — the structure looks arbitrary without knowing what it prevents. Say the word if you'd rather that archaeology live in an ADR.
- `gitnexus_detect_changes()` has not been run (MCP tools weren't available in the session that wrote this), so the CLAUDE.md pre-commit step is outstanding.
